### PR TITLE
adding --date to downloads-page-gen.py call

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -438,7 +438,7 @@ pipeline {
 
 		    // Generate the static download page directly from
 		    // the metadata.
-		    sh 'python3 ./scripts/downloads-page-gen.py -v --report ./combined.report.json --inject ./scripts/downloads-page-template.html > ./downloads.html'
+		    sh 'python3 ./scripts/downloads-page-gen.py -v --report ./combined.report.json --date $START_DATE --inject ./scripts/downloads-page-template.html > ./downloads.html'
 
 		    // Generate the a users.yaml report for missing data
 		    // in the GO pattern.


### PR DESCRIPTION
Just repeating the changes I saw in master. Jenkins reports this in snapshot:
```
python3 ./scripts/downloads-page-gen.py -v --report ./combined.report.json --inject ./scripts/downloads-page-template.html
09:46:54 INFO:downloads-page:Verbose: on
09:46:54 INFO:downloads-page:Will operate on: ./combined.report.json
09:46:54 ERROR:downloads-page:need a date argument
```