### PR TITLE
snapshot setting go-site branch to use gaferencer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
 	///
 
 	// The branch of geneontology/go-site to use.
-	TARGET_GO_SITE_BRANCH = 'master'
+	TARGET_GO_SITE_BRANCH = 'issue-1202-gaferencer_runner'
 	// The branch of minerva to use.
 	TARGET_MINERVA_BRANCH = 'master'
 	// The people to call when things go bad. It is a comma-space


### PR DESCRIPTION
per discussion yesterday, I'm setting snapshot to use the go-site branch where we have gaferencer turned on.