### PR TITLE
updating pipeline to match current ontology build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,8 +65,8 @@ pipeline {
 	    //"http://purl.obolibrary.org/obo/wbbt.owl",
 	    //"http://purl.obolibrary.org/obo/go/extensions/go-modules-annotations.owl",
 	    //"http://purl.obolibrary.org/obo/go/extensions/go-taxon-subsets.owl"
-            //"http://skyhook.berkeleybop.org/issue-35-neo-test/ontology/neo.owl"
-            "http://skyhook.berkeleybop.org/issue-35-neo-test/ontology/extensions/go-lego.owl"
+            "http://skyhook.berkeleybop.org/$BRANCH_NAME/ontology/neo.owl"
+            "http://skyhook.berkeleybop.org/$BRANCH_NAME/ontology/extensions/go-lego.owl"
 	].join(" ")
     }
     options{
@@ -332,25 +332,21 @@ pipeline {
 		sh 'rm blazegraph.jnl || true'
 		sh 'curl -L -o /tmp/blazegraph.jar https://github.com/blazegraph/database/releases/download/BLAZEGRAPH_2_1_6_RC/blazegraph.jar'
 		sh 'curl -L -o /tmp/blazegraph.properties https://raw.githubusercontent.com/geneontology/minerva/master/minerva-core/src/main/resources/org/geneontology/minerva/blazegraph.properties'
-		sh 'curl -L -o /tmp/go-lego.owl http://skyhook.berkeleybop.org/$BRANCH_NAME/ontology/extensions/go-lego.owl'
+		sh 'curl -L -o /tmp/go-lego-reacto.owl http://skyhook.berkeleybop.org/$BRANCH_NAME/ontology/extensions/go-lego-reacto.owl'
 		// BUG/TODO: This will need to point inward.
-		sh 'curl -L -o /tmp/reacto.owl http://snapshot.geneontology.org/ontology/extensions/reacto.owl'
+		//sh 'curl -L -o /tmp/reacto.owl http://snapshot.geneontology.org/ontology/extensions/reacto.owl'
 		// WARNING: Having trouble getting the journal to the
 		// right location. Theoretically, if the pipeline
 		// choked at the wrong time, a hard-to-erase file
 		// could be left on the system. See "rm" above.
-		sh 'java -cp /tmp/blazegraph.jar com.bigdata.rdf.store.DataLoader -defaultGraph http://example.org /tmp/blazegraph.properties /tmp/go-lego.owl'
-		sh 'cp blazegraph.jnl /tmp/blazegraph-go-lego.jnl'
-		sh 'java -cp /tmp/blazegraph.jar com.bigdata.rdf.store.DataLoader -defaultGraph http://example.org /tmp/blazegraph.properties /tmp/reacto.owl'
+		sh 'java -cp /tmp/blazegraph.jar com.bigdata.rdf.store.DataLoader -defaultGraph http://example.org /tmp/blazegraph.properties /tmp/go-lego-reacto.owl'
+		sh 'java -cp /tmp/blazegraph.jar com.bigdata.rdf.store.DataLoader -defaultGraph http://example.org /tmp/blazegraph.properties /tmp/neo.owl'
 		sh 'mv blazegraph.jnl /tmp/blazegraph-go-lego-with-reacto.jnl'
-		sh 'pigz /tmp/blazegraph-go-lego.jnl'
 		sh 'pigz /tmp/blazegraph-go-lego-with-reacto.jnl'
 		withCredentials([file(credentialsId: 'skyhook-private-key', variable: 'SKYHOOK_IDENTITY')]) {
 		    // Copy over journal.
-		    sh 'rsync -avz -e "ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY" /tmp/blazegraph-go-lego.jnl.gz skyhook@skyhook.berkeleybop.org:/home/skyhook/$BRANCH_NAME/products/blazegraph/blazegraph-go-lego.jnl.gz'
 		    sh 'rsync -avz -e "ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY" /tmp/blazegraph-go-lego-with-reacto.jnl.gz skyhook@skyhook.berkeleybop.org:/home/skyhook/$BRANCH_NAME/products/blazegraph/blazegraph-go-lego-with-reacto.jnl.gz'
 		    // DANGEROUS! WARNING/TODO: Copy over to temporary holding location for ShEx. Pseudo-publish.
-		    sh 'rsync -avz -e "ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY" /tmp/blazegraph-go-lego.jnl.gz skyhook@skyhook.berkeleybop.org:/home/skyhook/blazegraph-go-lego.jnl.gz'
 		    sh 'rsync -avz -e "ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY" /tmp/blazegraph-go-lego-with-reacto.jnl.gz skyhook@skyhook.berkeleybop.org:/home/skyhook/blazegraph-go-lego-with-reacto.jnl.gz'
 		}
 	    }


### PR DESCRIPTION
neo.owl needs to be imported explicitly into GOLR and the blazegraph journal running minerva ( blazegraph-go-lego-with-reacto.jnl)

See no need to have two blazegraph journals (one with reacto and one without).  Shouldn't harm anything to have reacto in there.