### PR TITLE
Switch PANTHER trees to version 15.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
 	/// PANTHER/PAINT metadata.
 	///
 
-	PANTHER_VERSION = '14.1'
+	PANTHER_VERSION = '15.0'
 	// Currently unused, but see:
 	// https://github.com/geneontology/pipeline/issues/86
 	PAINT_RELEASE = 'XXXX-YY-ZZ'


### PR DESCRIPTION
This will cause the PANTHER `tree_files.tar.gz` and `names.tab` files to be grabbed from:
http://data.pantherdb.org/PANTHER15.0/globals/

@kltm I'll watch for you to merge this change before switching the IBA GAF symlink to point to the new 15.0 IBA GAFs, so that there won't be a tree/IBA version mismatch in `snapshot`. Just let me know when you intend for this Jenkinsfile change to run. I'm guessing tonight or tomorrow night?

BTW: The IBA GAF symlink ftp://ftp.pantherdb.org/downloads/paint/presubmission, once I switch it, will point to:
ftp://ftp.pantherdb.org/downloads/paint/15.0/2020-05-21/presubmission/