### PR TITLE
Save gaferences as products. New stage for ontobio-parse-assocs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -691,7 +691,7 @@ pipeline {
 				sh 'pigz /opt/go-site/annotations_new/*'
 				sh 'pigz /opt/go-site/gaferencer-products/all.gaferences.json'
 				sh 'scp -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY /opt/go-site/annotations_new/* skyhook@skyhook.berkeleybop.org:/home/skyhook/$BRANCH_NAME/annotations'
-				sh 'scp -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY /opt/go-site/gaferencer-products/all.gaferences.json.gz skyhook@skyhook.berkeleybop.org:/home/skyhook/$BRANCH_NAME/products/gaferencer'
+				sh 'scp -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY /opt/go-site/gaferencer-products/all.gaferences.json.gz skyhook@skyhook.berkeleybop.org:/home/skyhook/$BRANCH_NAME/products/gaferencer/gaferences.json.gz'
 			}
 		}
 	}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -623,9 +623,7 @@ pipeline {
 		    }
 		    // Tarball and copy over gaferences.json to /products/gaferencer/
 		    sh 'find /opt/go-site/pipeline/target/groups -type f -regex "^.*.\\gaferences.json$" -exec cp {} /opt/go-site/gaferencer-products/ \\;'
-			dir('./opt/go-site/gaferencer-products') {
-		    	sh 'tar --use-compress-program=pigz -cvf gaferences.json.tgz *.gaferences.json'
-			}
+			sh 'tar --use-compress-program=pigz -cvf /opt/go-site/gaferencer-products/gaferences.json.tgz -C /opt/go-site/gaferencer-products *.gaferences.json'
 		    sh 'scp -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY /opt/go-site/gaferencer-products/gaferences.json.tgz skyhook@skyhook.berkeleybop.org:/home/skyhook/$BRANCH_NAME/products/gaferencer'
 		    // Flatten the TTLs into products/ttl/.
 		    sh 'find /opt/go-site/pipeline/target/groups -type f -name "*.ttl.gz" -exec scp -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY {} skyhook@skyhook.berkeleybop.org:/home/skyhook/$BRANCH_NAME/products/ttl \\;'
@@ -663,40 +661,37 @@ pipeline {
 	    }
 
 	    steps {
-		    sh "mkdir -p /tmp/annotations"
-		    sh "mkdir -p /tmp/annotations_new"
-		    sh "mkdir -p /tmp/gaferencer"
+		    // Prepare a working directory based around go-site.
+		    sh "cd /opt/ && git clone -b $TARGET_GO_SITE_BRANCH https://github.com/geneontology/go-site.git"
+
+		    sh "mkdir -p /opt/go-site/annotations"
+		    sh "mkdir -p /opt/go-site/annotations_new"
+		    sh "mkdir -p /opt/go-site/gaferencer-products"
 
 		    // Download gaferencer products and /annotations
 		    withCredentials([file(credentialsId: 'skyhook-private-key', variable: 'SKYHOOK_IDENTITY')]) {
-				sh "rsync -avz -e \"ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY\" skyhook@skyhook.berkeleybop.org:/home/skyhook/$BRANCH_NAME/annotations/*  /tmp/annotations/"
-				sh "rsync -avz -e \"ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY\" skyhook@skyhook.berkeleybop.org:/home/skyhook/$BRANCH_NAME/products/gaferencer/gaferences.json.tgz  /tmp/gaferencer/"
+				sh "rsync -avz -e \"ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY\" skyhook@skyhook.berkeleybop.org:/home/skyhook/$BRANCH_NAME/annotations/*  /opt/go-site/annotations/"
+				sh "rsync -avz -e \"ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY\" skyhook@skyhook.berkeleybop.org:/home/skyhook/$BRANCH_NAME/products/gaferencer/gaferences.json.tgz  /opt/go-site/gaferencer-products/"
 			}
 
-			// Extract gaferences tarball - likely will create '/tmp/gaferencer/target/groups/{group}/' directories
-			dir('./tmp/gaferencer') {
-				sh "tar -xvf gaferences.json.tgz"
-			}
-			// Prepare a working directory based around go-site.
-			dir('./go-site') {
-				git branch: TARGET_GO_SITE_BRANCH, url: 'https://github.com/geneontology/go-site.git'
-				// Concatenate all gaferences.json files into one large JSON object, then write to all.gaferences.json
-				sh 'python3 scripts/json-concat-lists.py /tmp/gaferencer/*.gaferences.json /tmp/gaferencer/all.gaferences.json'
-			}
+			// Extract gaferences tarball
+			sh "tar -xvf /opt/go-site/gaferencer-products/gaferences.json.tgz -C /opt/go-site/gaferencer-products"
+			// Concatenate all gaferences.json files into one large JSON object, then write to all.gaferences.json
+			sh 'python3 /opt/go-site/scripts/json-concat-lists.py /opt/go-site/gaferencer-products/*.gaferences.json /opt/go-site/gaferencer-products/all.gaferences.json'
 
 			// Uncompress all files in /tmp/annotations.
-			sh 'unpigz /tmp/annotations/*.gz'
+			sh 'unpigz /opt/go-site/annotations/*.gz'
 			// This should provide absolute paths in $f for all files in /tmp/annotations. Just plug in 'ontobio-parse-assocs' cmd
 			// by replacing 'echo $f'.
-			sh 'for f in /tmp/annotations/* ; do echo $f ; done'
+			sh 'for f in /opt/go-site/annotations/* ; do echo $f ; done'
 
 			// After ontobio-parse-assocs is run and we're all done, zip up all.gaferences.json, all annotations_new/ files, and then upload.
 			// annotations_new/ files will clobber existing files in skyhook/$BRANCH_NAME/annotations.
 			withCredentials([file(credentialsId: 'skyhook-private-key', variable: 'SKYHOOK_IDENTITY')]) {
-				sh 'pigz /tmp/annotations_new/*'
-				sh 'pigz /tmp/gaferencer/all.gaferences.json'
-				sh 'scp -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY /tmp/annotations_new/* skyhook@skyhook.berkeleybop.org:/home/skyhook/$BRANCH_NAME/annotations'
-				sh 'scp -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY /tmp/gaferencer/all.gaferences.json.gz skyhook@skyhook.berkeleybop.org:/home/skyhook/$BRANCH_NAME/products/gaferencer'
+				sh 'pigz /opt/go-site/annotations_new/*'
+				sh 'pigz /opt/go-site/gaferencer-products/all.gaferences.json'
+				sh 'scp -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY /opt/go-site/annotations_new/* skyhook@skyhook.berkeleybop.org:/home/skyhook/$BRANCH_NAME/annotations'
+				sh 'scp -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY /opt/go-site/gaferencer-products/all.gaferences.json.gz skyhook@skyhook.berkeleybop.org:/home/skyhook/$BRANCH_NAME/products/gaferencer'
 			}
 		}
 	}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -513,6 +513,7 @@ pipeline {
 		// sh "pwd"
 		sh "mkdir -p /opt/bin"
 		sh "mkdir -p /opt/lib"
+		sh "mkdir -p /opt/go-site/gaferencer-products"
 		// git branch: TARGET_GO_SITE_BRANCH, url: 'https://github.com/geneontology/go-site.git'
 
 		withCredentials([file(credentialsId: 'skyhook-private-key', variable: 'SKYHOOK_IDENTITY')]) {
@@ -621,9 +622,11 @@ pipeline {
 			}
 		    }
 		    // Tarball and copy over gaferences.json to /products/gaferencer/
-		    sh 'find /opt/go-site/pipeline/target/groups -type f -regex "^.*.\\gaferences.json$" -exec cp {} . \\;'
-		    sh 'tar --use-compress-program=pigz -cvf gaferences.json.tgz *.gaferences.json'
-		    sh 'scp -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY gaferences.json.tgz skyhook@skyhook.berkeleybop.org:/home/skyhook/$BRANCH_NAME/products/gaferencer'
+		    sh 'find /opt/go-site/pipeline/target/groups -type f -regex "^.*.\\gaferences.json$" -exec cp {} /opt/go-site/gaferencer-products/ \\;'
+			dir('./opt/go-site/gaferencer-products') {
+		    	sh 'tar --use-compress-program=pigz -cvf gaferences.json.tgz *.gaferences.json'
+			}
+		    sh 'scp -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY /opt/go-site/gaferencer-products/gaferences.json.tgz skyhook@skyhook.berkeleybop.org:/home/skyhook/$BRANCH_NAME/products/gaferencer'
 		    // Flatten the TTLs into products/ttl/.
 		    sh 'find /opt/go-site/pipeline/target/groups -type f -name "*.ttl.gz" -exec scp -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY {} skyhook@skyhook.berkeleybop.org:/home/skyhook/$BRANCH_NAME/products/ttl \\;'
 		    // Compress the journals.
@@ -671,7 +674,7 @@ pipeline {
 			}
 
 			// Extract gaferences tarball - likely will create '/tmp/gaferencer/target/groups/{group}/' directories
-			dir('/tmp/gaferencer') {
+			dir('./tmp/gaferencer') {
 				sh "tar -xvf gaferences.json.tgz"
 			}
 			// Prepare a working directory based around go-site.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -652,7 +652,8 @@ pipeline {
 	    }
 	}
 	// Redownload annotations and run ontobio-parse-assocs over them.
-	stage('Run ontobio-parse-assocs') {
+	// This stage is a hack required to work around data damage described in https://github.com/geneontology/go-site/issues/1484
+	stage('Temporary post filter') {
 	    agent {
 	    	docker {
 		    image 'geneontology/dev-base:eb2f253bb0ff780e1b623adde6d5537c55c31224_2019-08-13T163314'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -220,6 +220,7 @@ pipeline {
 			sh 'mkdir -p $WORKSPACE/mnt/$BRANCH_NAME/products/pages || true'
 			sh 'mkdir -p $WORKSPACE/mnt/$BRANCH_NAME/products/solr || true'
 			sh 'mkdir -p $WORKSPACE/mnt/$BRANCH_NAME/products/panther || true'
+			sh 'mkdir -p $WORKSPACE/mnt/$BRANCH_NAME/products/gaferencer || true'
 			sh 'mkdir -p $WORKSPACE/mnt/$BRANCH_NAME/metadata || true'
 			sh 'mkdir -p $WORKSPACE/mnt/$BRANCH_NAME/annotations || true'
 			sh 'mkdir -p $WORKSPACE/mnt/$BRANCH_NAME/ontology || true'
@@ -619,6 +620,10 @@ pipeline {
 			    echo "NOTE: At least on uniprot core file not found for this run to copy."
 			}
 		    }
+		    // Tarball and copy over gaferences.json to /products/gaferencer/
+		    sh 'find /opt/go-site/pipeline/target/groups -type f -regex "^.*.\\gaferences.json$" -exec cp {} . \\;'
+		    sh 'tar --use-compress-program=pigz -cvf gaferences.json.tgz *.gaferences.json'
+		    sh 'scp -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY gaferences.json.tgz skyhook@skyhook.berkeleybop.org:/home/skyhook/$BRANCH_NAME/products/gaferencer'
 		    // Flatten the TTLs into products/ttl/.
 		    sh 'find /opt/go-site/pipeline/target/groups -type f -name "*.ttl.gz" -exec scp -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY {} skyhook@skyhook.berkeleybop.org:/home/skyhook/$BRANCH_NAME/products/ttl \\;'
 		    // Compress the journals.
@@ -644,6 +649,53 @@ pipeline {
 		}
 
 	    }
+	}
+	// Redownload annotations and run ontobio-parse-assocs over them.
+	stage('Run ontobio-parse-assocs') {
+	    agent {
+	    	docker {
+		    image 'geneontology/dev-base:eb2f253bb0ff780e1b623adde6d5537c55c31224_2019-08-13T163314'
+		    args "-u root:root --tmpfs /opt:exec -w /opt"
+		}
+	    }
+
+	    steps {
+		    sh "mkdir -p /tmp/annotations"
+		    sh "mkdir -p /tmp/annotations_new"
+		    sh "mkdir -p /tmp/gaferencer"
+
+		    // Download gaferencer products and /annotations
+		    withCredentials([file(credentialsId: 'skyhook-private-key', variable: 'SKYHOOK_IDENTITY')]) {
+				sh "rsync -avz -e \"ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY\" skyhook@skyhook.berkeleybop.org:/home/skyhook/$BRANCH_NAME/annotations/*  /tmp/annotations/"
+				sh "rsync -avz -e \"ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY\" skyhook@skyhook.berkeleybop.org:/home/skyhook/$BRANCH_NAME/products/gaferencer/gaferences.json.tgz  /tmp/gaferencer/"
+			}
+
+			// Extract gaferences tarball - likely will create '/tmp/gaferencer/target/groups/{group}/' directories
+			dir('/tmp/gaferencer') {
+				sh "tar -xvf gaferences.json.tgz"
+			}
+			// Prepare a working directory based around go-site.
+			dir('./go-site') {
+				git branch: TARGET_GO_SITE_BRANCH, url: 'https://github.com/geneontology/go-site.git'
+				// Concatenate all gaferences.json files into one large JSON object, then write to all.gaferences.json
+				sh 'python3 scripts/json-concat-lists.py /tmp/gaferencer/*.gaferences.json /tmp/gaferencer/all.gaferences.json'
+			}
+
+			// Uncompress all files in /tmp/annotations.
+			sh 'unpigz /tmp/annotations/*.gz'
+			// This should provide absolute paths in $f for all files in /tmp/annotations. Just plug in 'ontobio-parse-assocs' cmd
+			// by replacing 'echo $f'.
+			sh 'for f in /tmp/annotations/* ; do echo $f ; done'
+
+			// After ontobio-parse-assocs is run and we're all done, zip up all.gaferences.json, all annotations_new/ files, and then upload.
+			// annotations_new/ files will clobber existing files in skyhook/$BRANCH_NAME/annotations.
+			withCredentials([file(credentialsId: 'skyhook-private-key', variable: 'SKYHOOK_IDENTITY')]) {
+				sh 'pigz /tmp/annotations_new/*'
+				sh 'pigz /tmp/gaferencer/all.gaferences.json'
+				sh 'scp -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY /tmp/annotations_new/* skyhook@skyhook.berkeleybop.org:/home/skyhook/$BRANCH_NAME/annotations'
+				sh 'scp -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY /tmp/gaferencer/all.gaferences.json.gz skyhook@skyhook.berkeleybop.org:/home/skyhook/$BRANCH_NAME/products/gaferencer'
+			}
+		}
 	}
 	// A new step to think about. What is our core metadata?
 	stage('Produce metadata') {


### PR DESCRIPTION
For issue https://github.com/geneontology/go-site/issues/1484.

Requires `TARGET_GO_SITE_BRANCH` to have `go-site/scripts/json-concat-lists.py`.

Also, the ontobio-parse-assocs command can replace the `echo $f` here:
https://github.com/geneontology/pipeline/blob/68a14fd5bc00569edaaf1b960f922c1c933c6bf2/Jenkinsfile#L686