### PR TITLE
Update stats script

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -946,7 +946,7 @@ pipeline {
 		    echo "Check that results have been stored properly"
 		    sh "curl 'http://localhost:8080/solr/select?q=*:*&rows=0'"
 		    echo "End of results"
-		    sh 'python3 /tmp/go_reports.py -g http://localhost:8080/solr/ -s http://current.geneontology.org/release_stats/go-stats.json -n http://current.geneontology.org/release_stats/go-stats-no-pb.json -c http://skyhook.berkeleybop.org/$BRANCH_NAME/ontology/go.obo -p http://current.geneontology.org/ontology/go.obo -r https://geneontology-archive.s3.amazonaws.com/2020-06-01/go-references.tsv -o /tmp/stats/ -d $START_DATE'
+		    sh 'python3 /tmp/go_reports.py -g http://localhost:8080/solr/ -s https://geneontology-archive.s3.amazonaws.com/2020-06-01/go-stats.json -n https://geneontology-archive.s3.amazonaws.com/2020-06-01/go-stats-no-pb.json -c http://skyhook.berkeleybop.org/$BRANCH_NAME/ontology/go.obo -p http://current.geneontology.org/ontology/go.obo -r https://geneontology-archive.s3.amazonaws.com/2020-06-01/go-references.tsv -o /tmp/stats/ -d $START_DATE'
 		    sh 'wget -N http://current.geneontology.org/release_stats/aggregated-go-stats-summaries.json'
 
 		    // Roll the stats forward.


### PR DESCRIPTION
-s -n parameters have to target temporary stats files due to the added field by_qualifier currently not present in the last release.
This will be reverted back to current.geneontology.org/release_stats/ after a release has produced the new stats files