### PR TITLE
Update blazegraph-runner version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -326,13 +326,13 @@ pipeline {
 		    },
 		    "Ready blazegraph-runner": {
 			dir('./blazegraph-runner') {
-			    sh 'wget -N https://github.com/balhoff/blazegraph-runner/releases/download/v1.4/blazegraph-runner-1.4.tgz'
-			    sh 'tar -xvf blazegraph-runner-1.4.tgz'
+			    sh 'wget -N https://github.com/balhoff/blazegraph-runner/releases/download/v1.6.5/blazegraph-runner-1.6.5.tgz'
+			    sh 'tar -xvf blazegraph-runner-1.6.5.tgz'
 			    withCredentials([file(credentialsId: 'skyhook-private-key', variable: 'SKYHOOK_IDENTITY')]) {
 				// Attempt to rsync bin into bin/.
-				sh 'rsync -avz -e "ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY" blazegraph-runner-1.4/bin/* skyhook@skyhook.berkeleybop.org:/home/skyhook/$BRANCH_NAME/bin/'
+				sh 'rsync -avz -e "ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY" blazegraph-runner-1.6.5/bin/* skyhook@skyhook.berkeleybop.org:/home/skyhook/$BRANCH_NAME/bin/'
 				// Attempt to rsync libs into lib/.
-				sh 'rsync -avz -e "ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY" blazegraph-runner-1.4/lib/* skyhook@skyhook.berkeleybop.org:/home/skyhook/$BRANCH_NAME/lib/'
+				sh 'rsync -avz -e "ssh -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o IdentityFile=$SKYHOOK_IDENTITY" blazegraph-runner-1.6.5/lib/* skyhook@skyhook.berkeleybop.org:/home/skyhook/$BRANCH_NAME/lib/'
 			    }
 			}
 		    },


### PR DESCRIPTION
Blazegraph-runner pre-1.6.5 has a dependency which depends on long-deprecated API in the JVM, which has been removed in Java 11. This version fixes the issue. We don't use the features that trigger the problem, but this is just future-proofing.