### PR TITLE
Update ODK to latest, v1.3.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -399,7 +399,7 @@ pipeline {
 	stage('Produce ontology') {
 	    agent {
 		docker {
-		    image 'obolibrary/odkfull:v1.2.32'
+		    image 'obolibrary/odkfull:v1.3.1'
 		    // Reset Jenkins Docker agent default to original
 		    // root.
 		    args '-u root:root'


### PR DESCRIPTION
This aligns the pipeline with https://github.com/geneontology/go-ontology/pull/23671

The new ODK has new ROBOT functionality we can use in the ontology build.