### PR TITLE
Apply causalmf param to fetch causal gocam-models.json

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -462,7 +462,7 @@ pipeline {
 			// Run commands.
 			sh 'wget http://localhost:8888/models/go -O gocam-goterms.json'
 			sh 'wget http://localhost:8888/models/gp -O gocam-gps.json'
-			sh 'wget http://localhost:8888/models -O gocam-models.json'
+			sh 'wget http://localhost:8888/models?causalmf=2 -O gocam-models.json'
 			sh 'wget http://localhost:8888/models/pmid -O gocam-pmids.json'
 
 			// Upload to skyhook to the expected location.


### PR DESCRIPTION
For https://github.com/geneontology/web-gocam/issues/20.

Basically, merge this to `issue-265-go-cam-products` and then rerun the branch. The GO-CAM site should pick this new file up and load much faster.

FYI, I tested this with a local `web-gocam` instance pointed to a test S3 bucket folder and it appeared to work as planned. @tmushayahama should be able to reproduce my test.