### PR TITLE
Switch PANTHER trees to version 17.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,7 +72,7 @@ pipeline {
 	/// PANTHER/PAINT metadata.
 	///
 
-	PANTHER_VERSION = '15.0'
+	PANTHER_VERSION = '17.0'
 
 	///
 	/// Application tokens.


### PR DESCRIPTION
For geneontology/go-site#1926. This was tested successfully in #307.

This change will begin pulling the PANTHER tree files for PANTHER version 17.0. I will go ahead and switch the IBA GAF symlink on the PAINT FTP server now. This symlink points to the latest 17.0-based IBA GAF folder.