### PR TITLE
Update to ODK 1.4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -341,7 +341,7 @@ pipeline {
 	stage('Produce ontology (*)') {
 	    agent {
 		docker {
-		    image 'obolibrary/odkfull:v1.2.32'
+		    image 'obolibrary/odkfull:v1.4'
 		    // Reset Jenkins Docker agent default to original
 		    // root.
 		    args '-u root:root'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -341,7 +341,8 @@ pipeline {
 	stage('Produce ontology (*)') {
 	    agent {
 		docker {
-		    image 'obolibrary/odkfull:v1.4'
+		    // Upgrade test for: geneontology/go-ontology#25019, from v1.2.32
+    		    image 'obolibrary/odkfull:v1.4'
 		    // Reset Jenkins Docker agent default to original
 		    // root.
 		    args '-u root:root'


### PR DESCRIPTION
@kltm I would like to test this, but not deploy yet. We need to coordinate migration to ODK 1.4 with the ontology editors moving to Protege 5.6.1. These are synchronized with regard to OWL API version (and thus file serialization output). If it seems to go smoothly with the pipeline, we'll set a date for switching over the Protege version.