### PR TITLE
Test ODK; changes to user used

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -328,7 +328,7 @@ pipeline {
 	    agent {
 		docker {
 		    // Upgrade test for: geneontology/go-ontology#25019, from v1.2.32
-    		    image 'obolibrary/odkfull:v1.4'
+    		    image 'obolibrary/odkfull:dev'
 		    // Reset Jenkins Docker agent default to original
 		    // root.
 		    args '-u root:root'


### PR DESCRIPTION
@kltm — @matentzn asked that we test this version of ODK on our pipeline. They've made some changes so that it no longer runs as root by default (I think). Could you do a run from this branch when you are back in the office?

Do not merge this PR; we don't want to continue on this branch.