### PR TITLE
Update Jenkinsfile for python3.10 dev-base docker change

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -497,7 +497,7 @@ pipeline {
 	stage('Produce GAFs, TTLs, and journal (*)') {
 	    agent {
 		docker {
-		    image 'geneontology/dev-base:857fc148379e5afea6c27f798d4c62b2fadf3577_2021-04-27T182251'
+		    image 'geneontology/dev-base:ea32b54c822f7a3d9bf20c78208aca452af7ee80_2023-08-28T125255'
 		    args "-u root:root --tmpfs /opt:exec -w /opt"
 		}
 	    }
@@ -530,6 +530,10 @@ pipeline {
 		}
 		sh "chmod +x /opt/bin/*"
 
+		// Install the python requirements.
+		sh "cd /opt/go-site/scripts && pip3 install -r requirements.txt"
+		// Re-establish location in the filesystem expected by steps below.
+		sh "cd /opt/"
 		sh "python3 /opt/go-site/scripts/download_source_gafs.py organize --datasets /opt/go-site/metadata/datasets --source /opt/go-site/sources --target /opt/go-site/pipeline/target/groups/"
 		sh "rm /opt/go-site/sources/*"
 
@@ -654,7 +658,7 @@ pipeline {
 	stage('Temporary post filter') {
 	    agent {
 		docker {
-		    image 'geneontology/dev-base:857fc148379e5afea6c27f798d4c62b2fadf3577_2021-04-27T182251'
+		    image 'geneontology/dev-base:ea32b54c822f7a3d9bf20c78208aca452af7ee80_2023-08-28T125255'
 		    args "-u root:root --tmpfs /opt:exec -w /opt"
 		}
 	    }


### PR DESCRIPTION
This:

- Points the "Produce GAFs, etc." and "Temp post filter" stage docker images to the new image published by @sierra-moxon with https://github.com/geneontology/operations/commit/8165ed0a61e04bb18a29281f95d390409d4d1bc0.
- Adds another `pip install` step for the new `go-site/scripts/` [requirements.txt](https://github.com/geneontology/go-site/commit/06da85e7963f44138c14d7840c5f5f5363a5cfdb) file after @sierra-moxon separated out requirements.txt from the new dev-base `Dockerfile`.