### PR TITLE
Update PANTHER_VERSION to 19.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
 	/// PANTHER/PAINT metadata.
 	///
 
-	PANTHER_VERSION = '17.0'
+	PANTHER_VERSION = '19.0'
 
 	///
 	/// Application tokens.


### PR DESCRIPTION
For #399

This will cause the PANTHER19.0 tree_files.tar.gz to be pulled to correctly match the PANTHER19.0-based IBA GAFs that I will release (by switching the pantherftp current symlink) later today.