### PR TITLE
Update snapshot-post-fail Jenkinsfile for #399

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
 	/// PANTHER/PAINT metadata.
 	///
 
-	PANTHER_VERSION = '17.0'
+	PANTHER_VERSION = '19.0'
 
 	///
 	/// Application tokens.


### PR DESCRIPTION
For https://github.com/geneontology/pipeline/issues/399.

Change on `snapshot-post-fail`.