### PR TITLE
Update derivatives-from-goa Jenkinsfile for #399

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,7 +67,7 @@ pipeline {
 	/// PANTHER/PAINT metadata.
 	///
 
-	PANTHER_VERSION = '17.0'
+	PANTHER_VERSION = '19.0'
 
 	///
 	/// Application tokens.


### PR DESCRIPTION
For https://github.com/geneontology/pipeline/issues/399.

Change on `derivatives-from-goa`.