### PR TITLE
Update ODK to 1.5.4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -328,7 +328,7 @@ pipeline {
 	    agent {
 		docker {
 		    // Upgrade test for: geneontology/go-ontology#25019, from v1.2.32
-    		    image 'obolibrary/odkfull:v1.4'
+    		    image 'obolibrary/odkfull:v1.5.4'
 		    // Reset Jenkins Docker agent default to original
 		    // root.
 		    args '-u root:root'


### PR DESCRIPTION
Required for alignment with https://github.com/geneontology/go-ontology/pull/29753.

We are updating ODK so that we can use the latest ROBOT, which includes a number of features relevant to pending ontology issues.