### PR TITLE
Update Docker image version in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -328,7 +328,7 @@ pipeline {
 	    agent {
 		docker {
 		    // Upgrade test for: geneontology/go-ontology#25019, from v1.2.32
-    		    image 'obolibrary/odkfull:v1.5.4'
+    		    image 'obolibrary/odkfull:v1.6.1'
 		    // Reset Jenkins Docker agent default to original
 		    // root.
 		    args '-u root:root'


### PR DESCRIPTION
Updating the ontology pipeline also to this version, so we don't fall behind ODK, and have access to scala-cli tool added there.

https://github.com/geneontology/go-ontology/pull/31892